### PR TITLE
(feat) Allows for getting all plurbs by userid

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -8,8 +8,8 @@ var google = new Purest({ provider: 'google' });
 module.exports = function (app) {
   /* User Routes */
   app.route('/api/user')
-    .get(userController.getAllUsers)
-    .post(userController.createUser);
+    .get(userController.getAllUsers);
+    //.post(userController.createUser);
 
     //find or delete a user based off their unique Google ID
   app.route('/api/user/:googid')

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -35,6 +35,9 @@ module.exports = function (app) {
     .get(plurbController.getPlurb)
     .post(plurbController.deletePlurb);
 
+  app.route('/api/plurbs/:googId')
+    .get(plurbController.getPlurbsByGoogId);
+
   //callback route for OAuth
   app.route('/callback')
     .get(function (req, res) {

--- a/server/controllers/plurbController.js
+++ b/server/controllers/plurbController.js
@@ -1,4 +1,5 @@
 var Plurb = require('../db/dbconfig').Plurb;
+var User = require('../db/dbconfig').User;
 
 module.exports = {
   getAllPlurbs: function (req, res) {
@@ -48,4 +49,20 @@ module.exports = {
       console.error (err);
     });
   },
+
+  getPlurbsByGoogId: function (req, res) {
+    var userId;
+    var googId = req.params.googId;
+    User.find({where: {googid: googId} })
+    .then(function (user) {
+      userId = user.dataValues.id;
+    });
+    Plurb.findAll({where: {UserId: userId}})
+    .then(function (plurb) {
+      res.status(200).json(plurb);
+    })
+    .catch(function (err) {
+      console.error (err);
+    });
+  }
 };

--- a/server/controllers/plurbController.js
+++ b/server/controllers/plurbController.js
@@ -1,5 +1,4 @@
 var Plurb = require('../db/dbconfig').Plurb;
-var User = require('../db/dbconfig').User;
 
 module.exports = {
   getAllPlurbs: function (req, res) {
@@ -20,7 +19,7 @@ module.exports = {
     Plurb.create(plurbData)
     .then(function (plurb) {
       plurb.setUser(req.session.user);
-      //plurb.setTopic(2);
+      //plurb.setTopic(TODO:);
       res.status(201).json(plurb);
     })
     .catch(function (err) {
@@ -51,15 +50,10 @@ module.exports = {
   },
 
   getPlurbsByGoogId: function (req, res) {
-    var userId;
     var googId = req.params.googId;
-    User.find({where: {googid: googId} })
-    .then(function (user) {
-      userId = user.dataValues.id;
-    });
-    Plurb.findAll({where: {UserId: userId}})
-    .then(function (plurb) {
-      res.status(200).json(plurb);
+    Plurb.findAll({where: {UserGoogid: googId}})
+    .then(function (plurbs) {
+      res.status(200).json(plurbs);
     })
     .catch(function (err) {
       console.error (err);

--- a/server/controllers/plurbController.js
+++ b/server/controllers/plurbController.js
@@ -15,6 +15,7 @@ module.exports = {
     var plurbData = {
       text: req.body.text,
       location: JSON.stringify(req.body.location),
+      topic: req.body.topic
     };
     Plurb.create(plurbData)
     .then(function (plurb) {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -12,20 +12,20 @@ module.exports = {
     });
   },
 
-  createUser: function (req, res) {
-    var userData = {
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      email: req.body.email,
-    };
-    User.create(userData)
-    .then(function (user) {
-      res.status(201).json(user);
-    })
-    .catch(function (err) {
-      console.error (err);
-    });
-  },
+  // createUser: function (req, res) {
+  //   var userData = {
+  //     firstName: req.body.firstName,
+  //     lastName: req.body.lastName,
+  //     email: req.body.email,
+  //   };
+  //   User.create(userData)
+  //   .then(function (user) {
+  //     res.status(201).json(user);
+  //   })
+  //   .catch(function (err) {
+  //     console.error (err);
+  //   });
+  // },
 
   getUser: function (req, res) {
     var userId = req.params.googid;

--- a/server/db/dbconfig.js
+++ b/server/db/dbconfig.js
@@ -14,7 +14,12 @@ if (process.env.CLEARDB_DATABASE_URL){
 
 //The unique 'googid' property set by Google OAuth, it is NOT the 'id' set automatically by MySQL
 var User = sequelize.define('User', {
-  googid: Sequelize.STRING,
+  googid: {
+    type: Sequelize.STRING,
+    primaryKey: true,
+    autoIncrement: false,
+    allowNull: false,
+    },
   firstName: Sequelize.STRING,
   lastName: Sequelize.STRING,
   email: Sequelize.STRING,
@@ -43,7 +48,7 @@ Plurb.belongsTo(User);
 //Plurb.sync();
 // User.sync();
 // Topic.sync();
-sequelize.sync({force: true});
+sequelize.sync();
 
 exports.User = User;
 exports.Topic = Topic;

--- a/server/db/dbconfig.js
+++ b/server/db/dbconfig.js
@@ -19,21 +19,15 @@ var User = sequelize.define('User', {
   lastName: Sequelize.STRING,
   email: Sequelize.STRING,
   picture: Sequelize.STRING,
-  createdAt: Sequelize.DATE,
-  updatedAt: Sequelize.DATE
 });
 
 var Topic = sequelize.define('Topic', {
   name: Sequelize.STRING,
-  createdAt: Sequelize.DATE,
-  updatedAt: Sequelize.DATE
 });
 
 var Plurb = sequelize.define('Plurb', {
   text: Sequelize.STRING,
   location: Sequelize.STRING,
-  createdAt: Sequelize.DATE,
-  updatedAt: Sequelize.DATE
 });
 
 //add many:many relationships between User and Topic
@@ -42,14 +36,14 @@ Topic.belongsToMany(User, {through: 'UserTopic'});
 
 //add one to many relationship between one user and many plurbs and one topic with many plurbs.
 Plurb.belongsTo(User);
-Plurb.belongsTo(Topic);
+//Plurb.belongsTo(Topic);
 
 // creates these tables in MySQL if they don't already exist. Pass in {force: true}
 // to drop any existing user and message tables and make new ones.
-// Plurb.sync();
+//Plurb.sync();
 // User.sync();
 // Topic.sync();
-sequelize.sync();
+sequelize.sync({force: true});
 
 exports.User = User;
 exports.Topic = Topic;


### PR DESCRIPTION
Sets the "googid" (from Google OAuth) as the primary key on User model.
Removes unnecessary "createdAt" and "updatedAt" fields in schema models. (These are placed there by default by Sequelize)

Comments out createUser method. We will most likely always use the findOrCreate method instead.

Resolves #83
