### PR TITLE
(fix) Shorten cookie length

### DIFF
--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -39,7 +39,7 @@ module.exports = function (app, express) {
     saveUninitialized: true,
     cookie: {
       secure: false,
-      maxAge: 864000000
+      maxAge: 864000
     }
   }));
   app.use(grant);


### PR DESCRIPTION
Changes cookie length to 864,000 seconds or 10 days
Resolves #263 
